### PR TITLE
fix bug in #92

### DIFF
--- a/src/vue-aplayer.vue
+++ b/src/vue-aplayer.vue
@@ -708,6 +708,12 @@
         this.internalMusic = music
       },
 
+      musicList () {
+        this.shuffledList = this.getShuffledList()
+        this.currentMusic = this.shuffledList[0]
+        this.playIndex = 0
+      },
+
       currentMusic: {
         handler (music) {
           // async


### PR DESCRIPTION
修复 #92 中提到的bug：
使用监听，在 musicList 更新时对 shuffledList 进行一次更新，从而解决列表切换后的实际播放列表未更换的问题。
