### PR TITLE
preload missing default props

### DIFF
--- a/src/vue-aplayer.vue
+++ b/src/vue-aplayer.vue
@@ -184,7 +184,10 @@
        * @since 1.4.0
        * observable
        */
-      preload: String,
+      preload: {
+        type: String,
+        default: "none",
+      },
 
       /**
        * @since 1.4.0


### PR DESCRIPTION
Without this default addition, [README](https://github.com/SevenOutman/vue-aplayer/blob/develop/docs/README.md)'s "Audio attributes as props" table is wrong since having no props default will be the same as `auto` instead. 

| Name | Type | Default | Observable | Description |
| ---- | ---- | ------- | ---------- | ---------- |
| preload | String | *none* | true | The way to load music, can be 'none' 'metadata' or 'auto' |

That means, without `preload="none"` in the `<aplayer />`, it's up for the browser to decide. In Chrome v75, all assets are downloaded, for example.

### aplayer without preload props

![image](https://user-images.githubusercontent.com/1087109/60375922-01996700-99e2-11e9-966c-12314f4b9bcb.png)

### aplayer with preload props explicitly set to none

Observe that only one was downloaded, which is the first icon, that I clicked "Play" (and is currently playing)

![image](https://user-images.githubusercontent.com/1087109/60375955-30afd880-99e2-11e9-8c6e-397993f38971.png)


_P.S.: I wasn't sure which branch to merge, develop or master, so sent to develop one_